### PR TITLE
Support decoding framelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories(
 find_library(NVJPEG_LIBRARY nvjpeg ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
 
 find_library(NVJPEG2K_LIB
+    REQUIRED
     NAMES nvjpeg2k
     PATHS ${NVJPEG2K_PATH}/lib)
 
@@ -61,7 +62,7 @@ pybind11_add_module(
   "src/dicom.cpp" 
   "src/helpers.cpp"
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC ${NVJPEG2K_LIB} ${CUDART_LIB})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${NVJPEG2K_LIB} ${CUDART_LIB})
 
 
 

--- a/src/dicom.cpp
+++ b/src/dicom.cpp
@@ -79,7 +79,9 @@ std::vector<FrameInfo_t> getFrameInfo(const char* buffer, size_t size) {
       break;
     }
     else {
-      throw std::invalid_argument("Unexpected tag");
+      std::stringstream ss;
+      ss << "Unexpected tag: " << std::hex << tag;
+      throw std::runtime_error(ss.str());
     }
   }
   return result;

--- a/src/nvjpeg2k_decode.h
+++ b/src/nvjpeg2k_decode.h
@@ -96,6 +96,28 @@ py::array_t<uint16_t> decode_frames(
 );
 
 
+/*
+ * Run batched decode on multiple frames with offsets
+ *
+ * Args:
+ *    buffer - Data buffer of multiple frames
+ *    bufferSizes - Size of each frame buffer
+ *    rows - Rows in output image
+ *    cols - Cols in output image
+ *    batchSize - Batch size for decoding
+ *    
+ * Returns:
+ *  3D array of decoded pixel data
+ */
+py::array_t<uint16_t> decode_framelist(
+    const char* buffer,
+    std::vector<size_t> bufferSizes,
+    const size_t rows, 
+    const size_t cols,
+    const int batchSize
+);
+
+
 void pybind_init_dec(py::module &m); 
 
 }


### PR DESCRIPTION
Adds a multi-frame decode option that receives a bytestream of frames as input. This allows for frame offset calculation to be bypassed and handled outside pynvjpeg. This change is needed to read JPEG2K DICOMs with a nonstandard frame offset encoding / BOT.

Implementation notes:
* Input frames should be passed from python as a single joined bytestream. I attempted to use `std::vector<const char*>` to allow passing a list of frame buffers, but Pybind11 fails to properly cast nested types. 
* The method works with single frame inputs as well. We may want to consider combining single and multi-frame reading in the future.